### PR TITLE
Fix for redirecting of stdout problem

### DIFF
--- a/_metis.pyx
+++ b/_metis.pyx
@@ -7,7 +7,7 @@ import os
 import sys
 import tempfile
 
-from networkx.addons.metis import _types
+from networkx.addons.metis import types
 
 __all__ = ['part_graph', 'node_nd', 'compute_vertex_separator']
 
@@ -139,7 +139,7 @@ cdef void convert_graph(xadj, adjncy, _api.idx_t *nvtxs_ptr, _api.idx_t **_xadj_
 
 cdef void check_result(int result, msg) except *:
     if result != _api.METIS_OK:
-        raise _types.MetisError(msg)
+        raise types.MetisError(msg)
 
 
 def part_graph(xadj, adjncy, nparts, vwgt=None, vsize=None, adjwgt=None,

--- a/networkx/addons/metis/tests/test_metis.py
+++ b/networkx/addons/metis/tests/test_metis.py
@@ -68,3 +68,12 @@ class TestMetis(object):
             sorted(map(sorted,
                        [[(sep[0] + i) % n for i in range(1, n // 2)],
                         [(sep[1] + i) % n for i in range(1, n // 2)]])))
+
+    def test_MetisOptions(self):
+        n = 16
+        xadj, adjncy = make_cycle(n)
+        options = types.MetisOptions(niter=-2)
+        nose.tools.assert_raises_regexp(types.MetisError,
+                                        'Input Error: Incorrect niter.',
+                                        _metis.part_graph, xadj, adjncy, 2,
+                                        options=options)


### PR DESCRIPTION
Fixes errors concerning StringIO instance of `sys.stdout`.

@ysitu This line
```
    msg = unicode(tmp.read(), sys.stdout.encoding)
```
needs to be changed too.
```
AttributeError: StringIO instance has no attribute 'encoding'
```