### PR TITLE
Setup Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+
+python:
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+  - "pypy"
+  - "pypy3"
+
+before_install:
+
+ - sudo apt-get update
+ - sudo apt-get install build-essential
+
+install:
+ - pip install Cython
+ - pip install https://github.com/networkx/networkx/archive/master.zip
+ - pip install .
+
+script:
+ - cd `mktemp -d`  # Navigate into a temporary directory to avoid loading the local code
+ - nosetests networkx.addons.metis.tests.test_metis --nocapture --verbosity=2
+
+notifications:
+  email: false


### PR DESCRIPTION
Fixes #12 .

NOTES

* Currently, instead of `pip install networkx`, I'm installing [this branch](https://github.com/orkohunter/networkx/tree/addons) from my fork of networkx.
* Because of which, `nosetests` is checking the entire `networkx` + `networkx+metis` library.
* Building with branches `master` `setup` and `travis-ci` all merged in one `travis-test` over [https://travis-ci.org/OrkoHunter/networkx-metis](https://travis-ci.org/OrkoHunter/networkx-metis)
* Build status : Passing.

*But it's not ready yet.* Namespace packaging is done, but there seems to be a little problem while installing. `setup.py` is installing a strange file named `_metis.py` in the same location as `_metis.so` with the following content
```py
def __bootstrap__():
   global __bootstrap__, __loader__, __file__
   import sys, pkg_resources, imp
   __file__ = pkg_resources.resource_filename(__name__,'_metis.so')
   __loader__ = None; del __bootstrap__, __loader__
   imp.load_dynamic(__name__,__file__)
__bootstrap__()
```
This file is causing trouble and interfering while importing `networkx.addons.metis._metis`. Renaming the `.so` file doesn't help either, the new file is given the same name except for having `.py` extension.

Related : http://askubuntu.com/questions/442357/environment-setup-for-importing-a-userdefined-module/442363#comment917656_442363