### PR TITLE
Fix circular import

### DIFF
--- a/_metis.pyx
+++ b/_metis.pyx
@@ -7,7 +7,7 @@ import os
 import sys
 import tempfile
 
-from networkx.addons.metis import types
+from networkx.addons.metis import exceptions
 
 __all__ = ['part_graph', 'node_nd', 'compute_vertex_separator']
 
@@ -139,7 +139,7 @@ cdef void convert_graph(xadj, adjncy, _api.idx_t *nvtxs_ptr, _api.idx_t **_xadj_
 
 cdef void check_result(int result, msg) except *:
     if result != _api.METIS_OK:
-        raise types.MetisError(msg)
+        raise exceptions.MetisError(msg)
 
 
 def part_graph(xadj, adjncy, nparts, vwgt=None, vsize=None, adjwgt=None,

--- a/_metis.pyx
+++ b/_metis.pyx
@@ -139,7 +139,7 @@ cdef void convert_graph(xadj, adjncy, _api.idx_t *nvtxs_ptr, _api.idx_t **_xadj_
 
 cdef void check_result(int result, msg) except *:
     if result != _api.METIS_OK:
-        raise exceptions.MetisError(msg)
+        raise exceptions.MetisError(result, msg)
 
 
 def part_graph(xadj, adjncy, nparts, vwgt=None, vsize=None, adjwgt=None,

--- a/networkx/addons/metis/exceptions.py
+++ b/networkx/addons/metis/exceptions.py
@@ -1,16 +1,20 @@
+from networkx.addons.metis import types
 __all__ = ['MetisError']
+
 
 class MetisError(Exception):
     """Error returned by METIS"""
 
-    def __init__(self, rstatus):
-        """Types of return codes.
+    def __init__(self, rstatus, msg):
+        """Initializes a MetisError object.
 
-            ======================================== ==================
-            Returned normally                        METIS_OK
-            Returned due to erroneous inputs/options METIS_ERROR_INPUT
-            Returned due to insufficient memory      METIS_ERROR_MEMORY
-            Some other errors                        METIS_ERROR
-            ======================================== ==================
+        Parameters
+        ----------
+        rstatus : int
+            Error code returned by METIS.
+
+        msg : string
+            Error message returned by METIS.
         """
-        super(MetisError, self).__init__(rstatus)
+        super(MetisError, self).__init__('{0}: {1}'.format(
+            types.MetisRStatus(rstatus).name, msg))

--- a/networkx/addons/metis/exceptions.py
+++ b/networkx/addons/metis/exceptions.py
@@ -1,0 +1,16 @@
+__all__ = ['MetisError']
+
+class MetisError(Exception):
+    """Error returned by METIS"""
+
+    def __init__(self, rstatus):
+        """Types of return codes.
+
+            ======================================== ==================
+            Returned normally                        METIS_OK
+            Returned due to erroneous inputs/options METIS_ERROR_INPUT
+            Returned due to insufficient memory      METIS_ERROR_MEMORY
+            Some other errors                        METIS_ERROR
+            ======================================== ==================
+        """
+        super(MetisError, self).__init__(rstatus)

--- a/networkx/addons/metis/metis.py
+++ b/networkx/addons/metis/metis.py
@@ -14,6 +14,7 @@ import sys
 
 import networkx as nx
 
+from networkx.addons.metis import exceptions
 from networkx.addons.metis import _metis
 from networkx.addons.metis import types
 __all__ = ['node_nested_dissection', 'partition', 'vertex_separator',
@@ -89,7 +90,8 @@ def _convert_exceptions(convert_type, catch_types=None):
 
 @nx.utils.not_implemented_for('directed')
 @nx.utils.not_implemented_for('multigraph')
-@_convert_exceptions(nx.NetworkXError, (ValueError, TypeError, types.MetisError))
+@_convert_exceptions(
+    nx.NetworkXError, (ValueError, TypeError, exceptions.MetisError))
 def node_nested_dissection(G, weight='weight', options=None):
     """Compute a node ordering of a graph that reduces fill when the Laplacian
     matrix of the graph is LU factorized. The algorithm aims to minimize the
@@ -139,7 +141,8 @@ def node_nested_dissection(G, weight='weight', options=None):
 
 @nx.utils.not_implemented_for('directed')
 @nx.utils.not_implemented_for('multigraph')
-@_convert_exceptions(nx.NetworkXError, (ValueError, TypeError, types.MetisError))
+@_convert_exceptions(
+    nx.NetworkXError, (ValueError, TypeError, exceptions.MetisError))
 def partition(G, nparts, node_weight='weight', node_size='size',
               edge_weight='weight', tpwgts=None, ubvec=None, options=None,
               recursive=False):
@@ -261,7 +264,8 @@ def partition(G, nparts, node_weight='weight', node_size='size',
 
 @nx.utils.not_implemented_for('directed')
 @nx.utils.not_implemented_for('multigraph')
-@_convert_exceptions(nx.NetworkXError, (ValueError, TypeError, types.MetisError))
+@_convert_exceptions(
+    nx.NetworkXError, (ValueError, TypeError, exceptions.MetisError))
 def vertex_separator(G, weight='weight', options=None):
     """Compute a vertex separator that bisects a graph. The algorithm aims to
     minimize the sum of weights of vertices in the separator.

--- a/networkx/addons/metis/tests/test_metis.py
+++ b/networkx/addons/metis/tests/test_metis.py
@@ -1,7 +1,9 @@
 import itertools
 import nose.tools
 
-import _metis
+from networkx.addons.metis import exceptions
+from networkx.addons.metis import _metis
+from networkx.addons.metis import types
 
 
 def make_cycle(n):
@@ -73,7 +75,7 @@ class TestMetis(object):
         n = 16
         xadj, adjncy = make_cycle(n)
         options = types.MetisOptions(niter=-2)
-        nose.tools.assert_raises_regexp(types.MetisError,
+        nose.tools.assert_raises_regexp(exceptions.MetisError,
                                         'Input Error: Incorrect niter.',
                                         _metis.part_graph, xadj, adjncy, 2,
                                         options=options)

--- a/networkx/addons/metis/types.py
+++ b/networkx/addons/metis/types.py
@@ -3,7 +3,7 @@ import numbers
 import enums
 from networkx.addons.metis import _metis
 
-__all__ = ['MetisOptions', 'MetisError']
+__all__ = ['MetisOptions']
 
 
 class MetisOptions(object):
@@ -267,9 +267,3 @@ class MetisOptions(object):
             self.__class__.__name__,
             ', '.join('{0}={1}'.format(name, repr(getattr(self, name)))
                       for name in names))
-
-
-class MetisError(Exception):
-    """An error type generated from METIS"""
-    def __init__(self, rstatus):
-        super(MetisError, self).__init__(rstatus)


### PR DESCRIPTION
This includes the changes sent in to `travis-test` branch by @chebee7i .

@ysitu I think I'm clear now about the presence of `__init__.py` in `networkx/addons/metis/`. It is necessary. See, networkx and networkx-metis are sharing the common namespace `networkx.addons`. So, in both the directories there should be an `__init__.py` containing the line 
```py
__import__('pkg_resources').declare_namespace(__name__)
```
and *nothing* else. This establishes their relation of sharing a namespace. Any other package in future also needs the same configuration.

Now, if `networkx` and `networkx-metis` are both installed in the system, `networkx.addons` is a package but `networkx.addons.metis` is not because of the absence of `__init__.py`. So, that's why we need it.

I'll create a `test` branch shortly with current `master` `setup` and this `fix_circular_import`. We can try installing that branch.