### PR TITLE
Correct wrong import

### DIFF
--- a/networkx/addons/metis/exceptions.py
+++ b/networkx/addons/metis/exceptions.py
@@ -1,4 +1,4 @@
-from networkx.addons.metis import types
+from networkx.addons.metis import enums
 __all__ = ['MetisError']
 
 
@@ -17,4 +17,4 @@ class MetisError(Exception):
             Error message returned by METIS.
         """
         super(MetisError, self).__init__('{0}: {1}'.format(
-            types.MetisRStatus(rstatus).name, msg))
+            enums.MetisRStatus(rstatus).name, msg))


### PR DESCRIPTION
`enums` is needed to be imported instead of `types`.