### PR TITLE
Some style fixes

### DIFF
--- a/networkx/addons/metis/__init__.py
+++ b/networkx/addons/metis/__init__.py
@@ -81,7 +81,7 @@ def _convert_exceptions(convert_type, catch_types=None):
     def _convert_exceptions(func, *args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except catch_types or () as e:
+        except catch_types as e:
             exc = e
         except Exception as e:
             if catch_types is not None:
@@ -255,8 +255,9 @@ def partition(G, nparts, node_weight='weight', node_size='size',
         tpwgts = list(itertools.chain.from_iterable(tpwgts))
 
     with _zero_numbering(options):
-        objval, part = _metis.part_graph(xadj, adjncy, nparts, vwgt, vsize, adjwgt,
-                                         tpwgts, ubvec, options, recursive)
+        objval, part = _metis.part_graph(xadj, adjncy, nparts, vwgt, vsize,
+                                         adjwgt, tpwgts, ubvec, options,
+                                         recursive)
 
     parts = [[] for i in range(nparts)]
     for u, i in zip(G, part):


### PR DESCRIPTION
Fix https://landscape.io/github/OrkoHunter/networkx-metis/3/messages/error
* binary-op-exception (W0711):
 	Exception to catch is the result of a binary “%s” operation Used when the exception to catch is of the form “except A or B:”. If intending to catch multiple, rewrite as “except (A, B):”

It seems that populating `networkx/addons/metis/__init__.py` has generated a couple of cyclic imports.
https://landscape.io/github/OrkoHunter/networkx-metis/3/messages/smell

~~They can be fixed by using `from . import module` which I think is okay to do.~~
Nope. Can't fix that.