### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Cython
+networkx
+decorator
+six
+enum34


### PR DESCRIPTION
Fixes #34 

`networkx` needs to be `networkx>1.9.1`. But as we don't have a final decision on whether we are including it in `1.10` or not, I'm keeping it without the version number.