### PR TITLE
Install Cython with --no-cython-compile flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - build-essential
 
 install:
+ - pip install --upgrade pip
  - pip install --install-option="--no-cython-compile" Cython 
  - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - build-essential
 
 install:
- - pip install Cython
+ - pip install --install-option="--no-cython-compile" Cython 
  - pip install .
 
 script:


### PR DESCRIPTION
The `--no-cython-compile` flag is recommended over CI for faster installation.

Also, pip 7.0.0 and later cache installed packages automatically in 
the form of wheels. Subsequent installs are therefore much faster. Travis still has pip 6.x version.