### PR TITLE
Add pip cache directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ python:
   - "pypy"
   - "pypy3"
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
With the pip upgrade, this change is also necessary for the pip caching over Travis to work.