### PR TITLE
Minor doc fixes

### DIFF
--- a/doc/source/bibliography.rst
+++ b/doc/source/bibliography.rst
@@ -1,0 +1,11 @@
+..  -*- coding: utf-8 -*-
+
+Bibliography
+============
+
+.. [Langtangen04] H.P. Langtangen, "Python Scripting for Computational
+    Science.", Springer Verlag Series in Computational Science and
+    Engineering, 2004.
+
+.. [Martelli03]  A. Martelli, "Python in a Nutshell", O'Reilly Media
+   Inc, 2003.

--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -5,7 +5,7 @@ Download
 Software
 ~~~~~~~~
 
-Source and binary releases: https://pypi.python.org/pypi/networkx/
+Source and binary releases: https://pypi.python.org/pypi/networkx-metis/
 
 Github (latest development): https://github.com/networkx/networkx-metis/
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,6 +15,7 @@ Contents:
    download
    install
    reference/index
+   bibliography
 
 Indices and tables
 ==================

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -3,25 +3,24 @@
 Overview
 ========
 
-NetworkX-METIS is an add-on for the python language software NetworkX which depends uses METIS for graph partitioning.
+NetworkX-METIS is an add-on for the `NetworkX`_ python package using `METIS`_ for graph partitioning.
 
 
 Who uses NetworkX-METIS?
-------------------
-  
+------------------------
+
 Goals
 -----
 
 The Python programming language
 -------------------------------
 
-Python is a powerful programming language that allows simple and flexible representations of networks, and  clear and concise expressions of network algorithms (and other algorithms too).  Python has a vibrant and growing ecosystem of packages that NetworkX uses to provide more features such as numerical linear algebra and drawing.  In addition 
-Python is also an excellent "glue" language for putting together pieces of software from other languages which allows reuse of legacy code and engineering of high-performance algorithms [Langtangen04]_. 
+Python is a powerful programming language that allows simple and flexible representations of networks, and  clear and concise expressions of network algorithms (and other algorithms too).  Python has a vibrant and growing ecosystem of packages that NetworkX uses to provide more features such as numerical linear algebra and drawing.  In addition
+Python is also an excellent "glue" language for putting together pieces of software from other languages which allows reuse of legacy code and engineering of high-performance algorithms [Langtangen04]_.
 
-Equally important, Python is free, well-supported, and a joy to use. 
+Equally important, Python is free, well-supported, and a joy to use.
 
-In order to make the most out of NetworkX you will want to know how to write basic programs in Python.  
-Among the many guides to Python, we recommend the documentation at
+In order to make the most out of NetworkX-METIS you will want to know how to write basic programs in Python. Among the many guides to Python, we recommend the documentation at
 http://www.python.org and the text by Alex Martelli [Martelli03]_.
 
 Free software
@@ -47,3 +46,7 @@ What Next
  - :doc:`Installing </install>`
 
  - :doc:`Reference </reference/index>`
+
+ .. _NetworkX: http://http://networkx.github.io/
+
+ .. _METIS: http://glaros.dtc.umn.edu/gkhome/metis/metis/overview


### PR DESCRIPTION
This fixes the warnings that appear in https://readthedocs.org/builds/networkx-metis/3214597/ and some minor ambiguities.

Also, I really doubt the fact that the docs have to follow the exact format of it's parent project. Do we really need to have a section titled "The Python Programming Language"? This is a fairly new project, so removing "Who uses Networkx-METIS" seems natural to me.

All in all, I feel a lot of parts need to be changed in the docs where we are following NetworkX, but largely going out of path what this project actually is. It's a good practice to follow the parent project, but NetworkX and NetworkX-METIS are very different projects from a high-level point of view IMHO.